### PR TITLE
Move Worldbank logo inside the masthead and hide the navigation

### DIFF
--- a/www/_config.yml
+++ b/www/_config.yml
@@ -76,3 +76,5 @@ compress_html:
   clippings: all
   ignore:
     envs: development
+
+display_main_nav: false

--- a/www/_includes/masthead.html
+++ b/www/_includes/masthead.html
@@ -4,8 +4,6 @@
   {% include test_banner.html %}
 {% endif %}
 
-{% include worldbank_logo.html %}
-
 <div class="masthead">
   <div class="masthead__inner-wrap">
     <div class="masthead__menu">
@@ -17,6 +15,9 @@
           {{ site.masthead_title | default: site.title }}
           {% if site.subtitle %}<span class="site-subtitle">{{ site.subtitle }}</span>{% endif %}
         </a>
+
+        {% if site.display_main_nav %}
+
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
             <li class="masthead__menu-item">
@@ -24,6 +25,9 @@
             </li>
           {%- endfor -%}
         </ul>
+
+        {% endif %}
+
         {% if site.search == true %}
         <button class="search__toggle" type="button">
           <span class="visually-hidden">{{ site.data.ui-text[site.locale].search_label | default: "Toggle search" }}</span>
@@ -39,5 +43,8 @@
         <ul class="hidden-links hidden"></ul>
       </nav>
     </div>
+
+    {% include worldbank_logo.html %}
+
   </div>
 </div>

--- a/www/assets/css/main.scss
+++ b/www/assets/css/main.scss
@@ -30,12 +30,12 @@
 
 .worldbank-logo {
   padding: 0.5em 1em;
-  max-width: 1280px;
-  width: 100%;
-  text-align: right;
-  margin: 0 auto;
   img {
     max-width: 240px;
+  }
+  display: none;
+  @include breakpoint($small) {
+    display: block;
   }
 }
 


### PR DESCRIPTION
This hides the main navigation and moves the Worldbank logo inside the masthead. For now the Worldbank logo will be hidden on mobile. A future improvement can be to make the logo wrap beneath the masthead on mobile.

![screenshot-127 0 0 1_4000-2020 05 07-18_24_43](https://user-images.githubusercontent.com/1319083/81350575-39f0e380-9090-11ea-9fba-26b51168d7da.png)
