### PR TITLE
Pin to specific version of sdg-metadata-convert

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node-watch": "0.6.3",
     "pdf-puppeteer": "1.1.10",
     "read-excel-file": "4.0.5",
-    "sdg-metadata-convert": "github:worldbank/sdg-metadata-convert#master",
+    "sdg-metadata-convert": "github:worldbank/sdg-metadata-convert#0.2.0",
     "simple-git": "1.132.0",
     "xliff": "4.4.0",
     "xmlbuilder": "13.0.2",


### PR DESCRIPTION
This is to prevent any unexpected breakages (like before with the English PDFs) as the [sdg-metadata-convert project](https://github.com/worldbank/sdg-metadata-convert) continues development. We'll "pin" to version 0.2.0.