### PR TITLE
Create blank translations in each language when uploading new indicators

### DIFF
--- a/scripts/import-indicators.js
+++ b/scripts/import-indicators.js
@@ -13,17 +13,31 @@ const files = fs.readdirSync(sourceFolder).filter(file => {
 const conversions = files.map(sourceFile => {
     const sourcePath = path.join(sourceFolder, sourceFile)
     const targetFile = sourceFile.replace('.docx', '.pot')
+    const blankTranslationFile = sourceFile.replace('.docx', '.po')
     const targetPath = path.join(targetFolder, targetFile)
-    return [sourcePath, targetPath]
+    return [sourcePath, targetPath, blankTranslationFile]
 })
 
 importIndicators()
 
 async function importIndicators() {
     for (const conversion of conversions) {
-        const [inputFile, outputFile] = conversion
+        const [inputFile, outputFile, blankTranslationFile] = conversion
         try {
             const metadata = await wordTemplateInput.read(inputFile)
+            const indicatorIsNew = !fs.existsSync(outputFile);
+            if (indicatorIsNew) {
+                for (const languageFolder of fs.readdirSync('translations')) {
+                    if (languageFolder != 'templates') {
+                        const blankTranslationOutput = new sdgMetadataConvert.GettextOutput({
+                            language: languageFolder
+                        })
+                        const blankTranslationPath = path.join('translations', languageFolder, blankTranslationFile)
+                        await blankTranslationOutput.write(metadata, blankTranslationPath)
+                        console.log(`Converted ${inputFile} to ${blankTranslationPath}.`);
+                    }
+                }
+            }
             await gettextOutput.write(metadata, outputFile)
             console.log(`Converted ${inputFile} to ${outputFile}.`);
         } catch(e) {


### PR DESCRIPTION
This should ensure that the translation management system (Weblate) will automatically create "components" for newly-uploaded indicators.