### PR TITLE
Right-to-left for Arabic on website

### DIFF
--- a/www/_plugins/create_pages.rb
+++ b/www/_plugins/create_pages.rb
@@ -196,6 +196,7 @@ module SdgMetadataPlugins
       self.data['layout'] = layout
       self.data['title'] = title
       self.data['language'] = language
+      self.data['classes'] = 'language-' + language
       self.data.merge!(data)
       self.content = content
     end

--- a/www/assets/css/main.scss
+++ b/www/assets/css/main.scss
@@ -250,3 +250,9 @@
   margin-right: 20px;
   margin-bottom: 20px;
 }
+
+.language-ar {
+  .page__inner-wrap, .sidebar {
+    direction: rtl;
+  }
+}

--- a/www/assets/css/main.scss
+++ b/www/assets/css/main.scss
@@ -252,7 +252,9 @@
 }
 
 .language-ar {
-  .page__inner-wrap, .sidebar {
-    direction: rtl;
+  &.layout--indicator {
+    .page, .sidebar {
+      direction: rtl;
+    }
   }
 }


### PR DESCRIPTION
This is a quick change to make the contents of the metadata page and sidebar go right-to-left. This does not cover the downloaded PDFs, as that will be more involved.

![screenshot-127 0 0 1_4000-2020 12 30-09_09_57](https://user-images.githubusercontent.com/1319083/103356405-d4b68c00-4a7e-11eb-96af-04f53df7772b.png)
